### PR TITLE
MES-1882: Respond 304 NOT_MODIFIED for unchanged journals

### DIFF
--- a/src/common/application/api/HttpStatus.ts
+++ b/src/common/application/api/HttpStatus.ts
@@ -1,8 +1,9 @@
 export enum HttpStatus {
-  BAD_REQUEST           = 400,
-  UNAUTHORIZED          = 401,
-  FORBIDDEN             = 403,
-  NOT_FOUND             = 404,
+  NOT_MODIFIED = 304,
+  BAD_REQUEST = 400,
+  UNAUTHORIZED = 401,
+  FORBIDDEN = 403,
+  NOT_FOUND = 404,
   INTERNAL_SERVER_ERROR = 500,
-  BAD_GATEWAY           = 502,
+  BAD_GATEWAY = 502,
 }

--- a/src/functions/getJournal/application/service/FindJournal.ts
+++ b/src/functions/getJournal/application/service/FindJournal.ts
@@ -2,10 +2,25 @@ import { getJournal } from '../../framework/aws/DynamoJournalRepository';
 import { ExaminerWorkSchedule } from '../../../../common/domain/Journal';
 import { decompressJournal } from './journal-decompressor';
 import * as logger from '../../../../common/application/utils/logger';
+import { JournalNotFoundError } from '../../domain/errors/journal-not-found-error';
+import { JournalDecompressionError } from '../../domain/errors/journal-decompression-error';
+import { JournalRecord } from '../../domain/JournalRecord';
 
-export async function findJournal(staffNumber: string): Promise<ExaminerWorkSchedule | null> {
+/**
+ * Finds a journal with a specified staffNumber.
+ * Throws a JournalNotFoundError if it the repo could not find one.
+ * Throws a JournalDecompressionError if decompression fails
+ * @param staffNumber the staff number of the journal to find
+ */
+export async function findJournal(
+  staffNumber: string,
+  modifiedSinceTimestamp: number | null,
+): Promise<ExaminerWorkSchedule | null> {
   const journalRecord = await getJournal(staffNumber);
   if (!journalRecord) {
+    throw new JournalNotFoundError();
+  }
+  if (journalNotModifiedSince(journalRecord, modifiedSinceTimestamp)) {
     return null;
   }
 
@@ -13,6 +28,10 @@ export async function findJournal(staffNumber: string): Promise<ExaminerWorkSche
     return decompressJournal(journalRecord.journal);
   } catch (error) {
     logger.error(error);
-    return null;
+    throw new JournalDecompressionError();
   }
 }
+
+const journalNotModifiedSince = (journalRecord: JournalRecord, modifiedSinceTimestamp: number | null): boolean => {
+  return !!modifiedSinceTimestamp && journalRecord.lastUpdatedAt <= modifiedSinceTimestamp;
+};

--- a/src/functions/getJournal/domain/errors/journal-decompression-error.ts
+++ b/src/functions/getJournal/domain/errors/journal-decompression-error.ts
@@ -1,0 +1,6 @@
+export class JournalDecompressionError extends Error {
+  constructor() {
+    super();
+    Object.setPrototypeOf(this, JournalDecompressionError.prototype);
+  }
+}

--- a/src/functions/getJournal/domain/errors/journal-not-found-error.ts
+++ b/src/functions/getJournal/domain/errors/journal-not-found-error.ts
@@ -1,0 +1,6 @@
+export class JournalNotFoundError extends Error {
+  constructor() {
+    super();
+    Object.setPrototypeOf(this, JournalNotFoundError.prototype);
+  }
+}

--- a/src/functions/getJournal/framework/handler.ts
+++ b/src/functions/getJournal/framework/handler.ts
@@ -4,6 +4,7 @@ import { HttpStatus } from '../../../common/application/api/HttpStatus';
 import * as logger from '../../../common/application/utils/logger';
 import { findJournal } from '../application/service/FindJournal';
 import * as jwtDecode from 'jwt-decode';
+import { JournalNotFoundError } from '../domain/errors/journal-not-found-error';
 
 export async function handler(event: APIGatewayProxyEvent, fnCtx: Context) {
   const staffNumber = getStaffNumber(event.pathParameters);
@@ -24,12 +25,15 @@ export async function handler(event: APIGatewayProxyEvent, fnCtx: Context) {
 
   try {
     logger.info(`Finding journal for staff number ${staffNumber}`);
-    const journal = await findJournal(staffNumber);
+    const journal = await findJournal(staffNumber, 0);
     if (journal === null) {
-      return createResponse({}, HttpStatus.NOT_FOUND);
+      return createResponse({}, HttpStatus.NOT_MODIFIED);
     }
     return createResponse(journal);
   } catch (err) {
+    if (err instanceof JournalNotFoundError) {
+      return createResponse({}, HttpStatus.NOT_FOUND);
+    }
     logger.error(err);
     return createResponse('Unable to retrieve journal', HttpStatus.INTERNAL_SERVER_ERROR);
   }

--- a/src/functions/getJournal/framework/handler.ts
+++ b/src/functions/getJournal/framework/handler.ts
@@ -25,7 +25,7 @@ export async function handler(event: APIGatewayProxyEvent, fnCtx: Context) {
 
   try {
     logger.info(`Finding journal for staff number ${staffNumber}`);
-    const journal = await findJournal(staffNumber, 0);
+    const journal = await findJournal(staffNumber, getIfModifiedSinceHeaderAsTimestamp(event.headers));
     if (journal === null) {
       return createResponse({}, HttpStatus.NOT_MODIFIED);
     }
@@ -92,3 +92,9 @@ function getEmployeeIdStringProperty(employeeId: any): string | null {
   }
   return employeeId;
 }
+
+const getIfModifiedSinceHeaderAsTimestamp = (headers: { [headerName: string]: string }): number | null => {
+  const ifModfiedSinceHeader = headers['If-Modified-Since'];
+  const parsedIfModifiedSinceHeader = Date.parse(ifModfiedSinceHeader);
+  return Number.isNaN(parsedIfModifiedSinceHeader) ? null : parsedIfModifiedSinceHeader;
+};


### PR DESCRIPTION
# Description and relevant Jira numbers
* Parse and pass `If-Modified-Since` header down to `findJournal` function
* Compare parsed `If-Modified-Since` to the `lastUpdatedAt` timestamp in DynamoDB, return null if there has been no change
* Refactor `findJournal` to throw an error for not finding journal as opposed to returning null
* Use TypeMoq in `handler.spec.ts` to support throwing custom Error types from stubs

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [x] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [x] Reviewers selected in Github
- [ ] PR link added to JIRA