### PR TITLE
MES-1882: Allow If-Modified-Since to be in any case

### DIFF
--- a/src/functions/getJournal/framework/__tests__/handler.spec.ts
+++ b/src/functions/getJournal/framework/__tests__/handler.spec.ts
@@ -217,6 +217,20 @@ describe('getJournal handler', () => {
       expect(createResponse.default).toHaveBeenCalledWith(fakeJournal);
       moqFindJournal.verify(x => x(It.isValue('12345678'), It.isValue(1558624157000)), Times.once());
     });
+    it('should parse If-Modified-Since header in any casing', async () => {
+      process.env.EMPLOYEE_ID_VERIFICATION_DISABLED = 'true';
+      dummyApigwEvent.headers = {
+        'Content-Type': 'application/json',
+        Authorization: tokens.employeeId_01234567,
+        'If-MoDiFiEd-SiNce': 'Thu, 23 May 2019 15:09:17 GMT',
+      };
+      moqFindJournal.setup(x => x(It.isAny(), It.isAny())).returns(() => Promise.resolve(fakeJournal));
+      createResponseSpy.and.returnValue({ statusCode: 200 });
+
+      await handler(dummyApigwEvent, dummyContext);
+
+      moqFindJournal.verify(x => x(It.isValue('12345678'), It.isValue(1558624157000)), Times.once());
+    });
     it('should not error on a non-parsable If-Modified-Since header and pass instead of a timestamp', async () => {
       process.env.EMPLOYEE_ID_VERIFICATION_DISABLED = 'true';
       dummyApigwEvent.headers = {

--- a/src/functions/getJournal/framework/handler.ts
+++ b/src/functions/getJournal/framework/handler.ts
@@ -94,7 +94,12 @@ function getEmployeeIdStringProperty(employeeId: any): string | null {
 }
 
 const getIfModifiedSinceHeaderAsTimestamp = (headers: { [headerName: string]: string }): number | null => {
-  const ifModfiedSinceHeader = headers['If-Modified-Since'];
-  const parsedIfModifiedSinceHeader = Date.parse(ifModfiedSinceHeader);
-  return Number.isNaN(parsedIfModifiedSinceHeader) ? null : parsedIfModifiedSinceHeader;
+  for (const headerName of Object.keys(headers)) {
+    if (headerName.toLowerCase() === 'if-modified-since') {
+      const ifModfiedSinceHeaderValue = headers[headerName];
+      const parsedIfModifiedSinceHeader = Date.parse(ifModfiedSinceHeaderValue);
+      return Number.isNaN(parsedIfModifiedSinceHeader) ? null : parsedIfModifiedSinceHeader;
+    }
+  }
+  return null;
 };


### PR DESCRIPTION
# Description and relevant Jira numbers
* With regional APIG, custom headers (`If-Modified-Since` for instance) always come through in lower case.
* This caused discrepancy in header casing when receiving headers on an Edge optimised APIG directly vs via a regional custom domain name.
* Ensure that we accept `If-Modified-Since` in any casing by comparing the lowercased variant.

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [ ] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [x] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [x] Reviewers selected in Github
- [ ] PR link added to JIRA