### PR TITLE
MES-2857: Use request context to obtain authenticated staff number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5475,7 +5475,8 @@
     "jwt-decode": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
-      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
+      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=",
+      "dev": true
     },
     "kind-of": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@types/jwt-decode": "^2.2.1",
     "aws-sdk": "^2.389.0",
-    "jwt-decode": "^2.2.0",
     "moment": "^2.23.0"
   },
   "devDependencies": {

--- a/src/functions/getJournal/framework/__tests__/handler.spec.ts
+++ b/src/functions/getJournal/framework/__tests__/handler.spec.ts
@@ -36,7 +36,6 @@ describe('getJournal handler', () => {
     dummyApigwEvent.requestContext.authorizer = { staffNumber: '12345678' };
     dummyContext = lambdaTestUtils.mockContextCreator(() => null);
     process.env.EMPLOYEE_ID_VERIFICATION_DISABLED = undefined;
-    process.env.EMPLOYEE_ID_EXT_KEY = 'extn.employeeId';
     spyOn(FindJournal, 'findJournal').and.callFake(moqFindJournal.object);
   });
 

--- a/src/functions/getJournal/framework/__tests__/handler.spec.ts
+++ b/src/functions/getJournal/framework/__tests__/handler.spec.ts
@@ -114,12 +114,13 @@ describe('getJournal handler', () => {
     });
   });
 
-  describe('obtaining employee ID from token with array or non-array extension attributes', () => {
-    it('should get the employee ID from when the property is an array', async () => {
-      dummyApigwEvent.headers = {
-        'Content-Type': 'application/json',
-        Authorization: tokens.employeeId_12345678,
+  describe('obtaining employee ID from request context', () => {
+    it('should obtain a the employee ID from the request context, not the JWT', async () => {
+      dummyApigwEvent.requestContext.authorizer = {
+        staffNumber: '999999',
       };
+      // @ts-ignore
+      dummyApigwEvent.pathParameters.staffNumber = '999999';
       createResponseSpy.and.returnValue({ statusCode: 200 });
       moqFindJournal.setup(x => x(It.isAny(), It.isAny())).returns(() => Promise.resolve(fakeJournal));
 
@@ -127,20 +128,7 @@ describe('getJournal handler', () => {
 
       expect(resp.statusCode).toBe(200);
       expect(createResponse.default).toHaveBeenCalledWith(fakeJournal);
-    });
-    it('should get the employee ID from when the property is a string', async () => {
-      dummyApigwEvent.headers = {
-        'Content-Type': 'application/json',
-        Authorization: tokens.employeeId_notArray,
-      };
-      process.env.EMPLOYEE_ID_EXT_KEY = 'employeeid';
-      createResponseSpy.and.returnValue({ statusCode: 200 });
-      moqFindJournal.setup(x => x(It.isAny(), It.isAny())).returns(() => Promise.resolve(fakeJournal));
-
-      const resp = await handler(dummyApigwEvent, dummyContext);
-
-      expect(resp.statusCode).toBe(200);
-      expect(createResponse.default).toHaveBeenCalledWith(fakeJournal);
+      moqFindJournal.verify(x => x(It.isValue('999999'), It.isAny()), Times.once());
     });
   });
 

--- a/src/functions/getJournal/framework/__tests__/handler.spec.ts
+++ b/src/functions/getJournal/framework/__tests__/handler.spec.ts
@@ -126,7 +126,7 @@ describe('getJournal handler', () => {
         const resp = await handler(dummyApigwEvent, dummyContext);
 
         expect(resp.statusCode).toBe(401);
-        expect(createResponse.default).toHaveBeenCalledWith('Invalid authorisation token', 401);
+        expect(createResponse.default).toHaveBeenCalledWith('No staff number found in request context', 401);
       });
     });
   });

--- a/src/functions/getJournal/framework/handler.ts
+++ b/src/functions/getJournal/framework/handler.ts
@@ -1,9 +1,8 @@
-import { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import { APIGatewayProxyEvent, Context, APIGatewayEventRequestContext } from 'aws-lambda';
 import createResponse from '../../../common/application/utils/createResponse';
 import { HttpStatus } from '../../../common/application/api/HttpStatus';
 import * as logger from '../../../common/application/utils/logger';
 import { findJournal } from '../application/service/FindJournal';
-import * as jwtDecode from 'jwt-decode';
 import { JournalNotFoundError } from '../domain/errors/journal-not-found-error';
 
 export async function handler(event: APIGatewayProxyEvent, fnCtx: Context) {
@@ -13,7 +12,7 @@ export async function handler(event: APIGatewayProxyEvent, fnCtx: Context) {
   }
 
   if (process.env.EMPLOYEE_ID_VERIFICATION_DISABLED !== 'true') {
-    const employeeId = getEmployeeIdFromToken(event.headers.Authorization);
+    const employeeId = getEmployeeIdFromRequestContext(event.requestContext);
     if (employeeId === null) {
       return createResponse('Invalid authorisation token', HttpStatus.UNAUTHORIZED);
     }
@@ -51,50 +50,6 @@ function getStaffNumber(pathParams: { [key: string]: string } | null): string | 
   return pathParams.staffNumber;
 }
 
-function getEmployeeIdFromToken(token: string): string | null {
-  if (token === null) {
-    logger.warn('No authorisation token in request');
-    return null;
-  }
-
-  try {
-    const decodedToken: any = jwtDecode(token);
-    const employeeIdKey = process.env.EMPLOYEE_ID_EXT_KEY || '';
-    if (employeeIdKey.length === 0) {
-      logger.error('No key specified to find employee ID from JWT');
-      return null;
-    }
-
-    const employeeIdFromJwt = decodedToken[employeeIdKey];
-    if (!employeeIdFromJwt) {
-      logger.warn('No employeeId found in authorisation token');
-      return null;
-    }
-
-    return Array.isArray(employeeIdFromJwt) ?
-      getEmployeeIdFromArray(employeeIdFromJwt) : getEmployeeIdStringProperty(employeeIdFromJwt);
-  } catch (err) {
-    logger.error(err);
-    return null;
-  }
-}
-
-function getEmployeeIdFromArray(attributeArr: string[]): string | null {
-  if (attributeArr.length === 0) {
-    logger.warn('No employeeId found in authorisation token');
-    return null;
-  }
-  return attributeArr[0];
-}
-
-function getEmployeeIdStringProperty(employeeId: any): string | null {
-  if (typeof employeeId !== 'string' || employeeId.trim().length === 0) {
-    logger.warn('No employeeId found in authorisation token');
-    return null;
-  }
-  return employeeId;
-}
-
 const getIfModifiedSinceHeaderAsTimestamp = (headers: { [headerName: string]: string }): number | null => {
   for (const headerName of Object.keys(headers)) {
     if (headerName.toLowerCase() === 'if-modified-since') {
@@ -102,6 +57,13 @@ const getIfModifiedSinceHeaderAsTimestamp = (headers: { [headerName: string]: st
       const parsedIfModifiedSinceHeader = Date.parse(ifModfiedSinceHeaderValue);
       return Number.isNaN(parsedIfModifiedSinceHeader) ? null : parsedIfModifiedSinceHeader;
     }
+  }
+  return null;
+};
+
+const getEmployeeIdFromRequestContext = (requestContext: APIGatewayEventRequestContext): string | null => {
+  if (requestContext.authorizer && typeof requestContext.authorizer.staffNumber === 'string') {
+    return requestContext.authorizer.staffNumber;
   }
   return null;
 };

--- a/src/functions/getJournal/framework/handler.ts
+++ b/src/functions/getJournal/framework/handler.ts
@@ -14,7 +14,7 @@ export async function handler(event: APIGatewayProxyEvent, fnCtx: Context) {
   if (process.env.EMPLOYEE_ID_VERIFICATION_DISABLED !== 'true') {
     const employeeId = getEmployeeIdFromRequestContext(event.requestContext);
     if (employeeId === null) {
-      return createResponse('Invalid authorisation token', HttpStatus.UNAUTHORIZED);
+      return createResponse('No staff number found in request context', HttpStatus.UNAUTHORIZED);
     }
     if (employeeId !== staffNumber) {
       logger.warn(`Invalid staff number (${staffNumber}) requested by employeeId ${employeeId}`);


### PR DESCRIPTION
# Description and relevant Jira numbers
* Custom authoriser now places the authenticated staff number into the request context as per https://github.com/dvsa/mes-custom-authorizer/pull/24
* Navigate the `requestContext.authorizer` to get access to the authenticated `staffNumber`
* Remove explicit dependency on `jwt-decode` package

## Pull Request checklist

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop

## Sign off process checklist

- [x] Code has been tested manually
- [ ] Tested by QA
- [ ] PO's approval
- [x] Reviewers selected in Github
- [x] PR link added to JIRA